### PR TITLE
Fix platform detection of OSX ('darwin')

### DIFF
--- a/render.py
+++ b/render.py
@@ -96,7 +96,7 @@ def render_preview( engine, scene):
     appleseed_exe = os.path.join( as_bin_path, "appleseed.cli")
     
     # If running Linux/OSX, add the binary path to environment.
-    if 'win' not in sys.platform:
+    if sys.platform != "win32":
         os.environ['LD_LIBRARY_PATH'] = as_bin_path
 
     # Get the addon path so we can use the files in the material preview directory.
@@ -203,7 +203,7 @@ def render_scene( engine, scene):
     appleseed_exe = os.path.join( as_bin_path, ("appleseed.studio" if scene.appleseed.display_mode == 'STUDIO' else "appleseed.cli"))
     
     # If running Linux/OSX, add the binary path to environment.
-    if 'win' not in sys.platform:
+    if sys.platform != "win32":
         os.environ['LD_LIBRARY_PATH'] = as_bin_path
         
     scale = scene.render.resolution_percentage / 100.0


### PR DESCRIPTION
sys.platform returns `darwin` for OSX. As `win` is in `darwin` the old `if` didn't set the `LD_LIBRARY_PATH` on OSX. Unfortunately this fix doesn't solve the issue of not finding `libappleseed.dylib`, when starting `appleseed.cli` or `appleseed.studio` from within Blender.
I will open an issue for this problem.
