### PR TITLE
Small improvements and some bug fixes.

### DIFF
--- a/project_file_writer.pyx
+++ b/project_file_writer.pyx
@@ -1718,7 +1718,11 @@ class write_project_file( object):
             # Assume the path ends with '.png' or '.exr'.
             texture_name = texture.split( util.sep)[-1][:-4]
             filepath = texture
-            color_space = 'srgb'
+
+            if texture.endswith('.exr'):
+                color_space = 'srgb'
+            else:
+                color_space = 'linear_rgb'
         elif node is not None:
             texture_name = node.get_node_name()
             filepath = util.realpath( node.tex_path)
@@ -2161,7 +2165,7 @@ class write_project_file( object):
         self.__open_element("frame name=\"beauty\"")
         self.__emit_parameter("camera", "camera" if camera is None else camera.name)
         self.__emit_parameter("resolution", "{0} {1}".format(width, height))
-        self.__emit_custom_prop(scene, "color_space", "srgb")
+        self.__emit_custom_prop(scene, "color_space", "linear_rgb")
         if scene.render.use_border:
             X, Y, endX, endY = self.__get_border_limits(scene, width, height)
             self.__emit_parameter("crop_window", "{0} {1} {2} {3}".format(X, Y, endX, endY))

--- a/project_file_writer.pyx
+++ b/project_file_writer.pyx
@@ -1720,9 +1720,9 @@ class write_project_file( object):
             filepath = texture
 
             if texture.endswith('.exr'):
-                color_space = 'srgb'
-            else:
                 color_space = 'linear_rgb'
+            else:
+                color_space = 'srgb'
         elif node is not None:
             texture_name = node.get_node_name()
             filepath = util.realpath( node.tex_path)

--- a/properties/scene.py
+++ b/properties/scene.py
@@ -63,16 +63,6 @@ class AppleseedRenderSettings( bpy.types.PropertyGroup):
         cls.selected_camera = bpy.props.EnumProperty( name="Camera",
                                              description="Select the camera to export",
                                              items=camera_enumerator)
-
-        cls.display_mode = bpy.props.EnumProperty(  name = "Display",
-                                            description = "Select where rendered images will be displayed",
-                                            items=(( 'NONE', "Keep UI", ""),
-                                                   ( 'WINDOW', "New Window", ""),
-                                                   ( 'AREA', "Image Editor", ""),
-                                                   ( 'SCREEN', "Full Screen", ""),
-                                                   ( 'STUDIO', "Appleseed Studio", "")),
-                                            default = 'AREA')
-
         
         cls.studio_rendering_mode = bpy.props.EnumProperty( name = "Mode",
                                             description = "Rendering mode to be used after launching appleseed.studio",
@@ -87,12 +77,6 @@ class AppleseedRenderSettings( bpy.types.PropertyGroup):
                                             default = threads, 
                                             min = 1, 
                                             max = max_threads)
-
-        cls.refresh_time = bpy.props.FloatProperty( name = "Refresh Time", 
-                                            description = "Refresh rate of the rendered image into the image editor (in seconds)", 
-                                            default = 1.0, 
-                                            min = 0.1, 
-                                            max = 30)
 
         cls.generate_mesh_files = bpy.props.BoolProperty( name="Export Geometry",
                                             description = "Write geometry to disk as .obj files",
@@ -109,13 +93,6 @@ class AppleseedRenderSettings( bpy.types.PropertyGroup):
         cls.export_hair = bpy.props.BoolProperty( name = "Export Hair", 
                                         description = "Export hair particle systems as renderable geometry", 
                                         default = False)
-                                        
-        cls.img_extension = bpy.props.EnumProperty( name = "Image Format", 
-                                            description = "File format of rendered image", 
-                                            items = [( ".png", "PNG", "PNG: Output image in .png format"),
-                                            ( ".exr", "EXR", "EXR: Output image in .exr format")],
-                                            default = ".png")
-        
         # Sampling.
         cls.decorrelate_pixels = bpy.props.BoolProperty( name = "Decorrelate Pixels", description = '', default = True)
         

--- a/render.py
+++ b/render.py
@@ -163,7 +163,7 @@ def update_scene( engine, data, scene):
 def render_scene( engine, scene):
     # Write project file and export meshes.
     bpy.ops.appleseed.export()
-    DELAY = 1.0
+    DELAY = 1.0 # seconds
 
     if scene.appleseed.project_path == '':
         engine.report( {'INFO'}, "No project path has been specified!")
@@ -229,6 +229,10 @@ def render_scene( engine, scene):
             '--resolution', str(width), str(height),
             '--window', str(x), str(y), str(endX), str(endY))
 
+    # Remove previous renders.
+    if os.path.exists( img_file):
+        os.remove( img_file)
+
     # Launch appleseed.cli.
     process = subprocess.Popen( cmd, cwd=as_bin_path, env = os.environ.copy())
         
@@ -280,9 +284,9 @@ def render_scene( engine, scene):
             # check if the file updated
             new_size = os.path.getsize( img_file)
 
-            #if new_size != prev_size:
-            update_image()
-            #    prev_size = new_size
+            if new_size != prev_size:
+                update_image()
+                prev_size = new_size
 
             time.sleep( DELAY)
     

--- a/render.py
+++ b/render.py
@@ -163,7 +163,7 @@ def update_scene( engine, data, scene):
 def render_scene( engine, scene):
     # Write project file and export meshes.
     bpy.ops.appleseed.export()
-    DELAY = scene.appleseed.refresh_time
+    DELAY = 1.0
 
     if scene.appleseed.project_path == '':
         engine.report( {'INFO'}, "No project path has been specified!")
@@ -179,7 +179,7 @@ def render_scene( engine, scene):
             return            
     render_output = os.path.join( project_dir, "render")
     img_file = os.path.join( render_output,  
-                           ( scene.name + '_' + str( scene.frame_current) + scene.appleseed.img_extension))
+                           ( scene.name + '_' + str( scene.frame_current) + '.exr'))
     
     # Make the render directory, if it doesn't exist yet
     if not os.path.exists( render_output):
@@ -200,7 +200,7 @@ def render_scene( engine, scene):
     if as_bin_path == '':
         engine.report({'INFO'}, "The path to appleseed executable has not been specified. Set the path in the addon user preferences.")
         return
-    appleseed_exe = os.path.join( as_bin_path, ("appleseed.studio" if scene.appleseed.display_mode == 'STUDIO' else "appleseed.cli"))
+    appleseed_exe = os.path.join( as_bin_path, "appleseed.cli")
     
     # If running Linux/OSX, add the binary path to environment.
     if sys.platform != "win32":
@@ -211,30 +211,65 @@ def render_scene( engine, scene):
     height = int(scene.render.resolution_y * scale)
     
     # Start the appleseed.cli executable.
-    if scene.appleseed.display_mode != "STUDIO":      
-        scene.render.display_mode = scene.appleseed.display_mode  
-        # Border rendering (rectangle = resolution).
-        x, y, endX, endY = 0, 0, width, height
-        if scene.render.use_border:
-            x = int(scene.render.border_min_x * width)
-            y = height - int(scene.render.border_max_y * height)
-            endX = int(scene.render.border_max_x * width)    
-            endY = height - int(scene.render.border_min_y * height)
 
-        cmd = ( appleseed_exe,
-                filename, 
-                '-o', img_file, 
-                '--threads', str(threads),
-                '--continuous-saving',
-                '--message-verbosity', 'fatal',
-                '--resolution', str(width), str(height),
-                '--window', str(x), str(y), str(endX), str(endY))
+    # Border rendering (rectangle = resolution).
+    x, y, endX, endY = 0, 0, width, height
+    if scene.render.use_border:
+        x = int(scene.render.border_min_x * width)
+        y = height - int(scene.render.border_max_y * height)
+        endX = int(scene.render.border_max_x * width)    
+        endY = height - int(scene.render.border_min_y * height)
 
-        # Launch appleseed.cli.
-        process = subprocess.Popen( cmd, cwd=as_bin_path, env = os.environ.copy())
+    cmd = ( appleseed_exe,
+            filename, 
+            '-o', img_file, 
+            '--threads', str(threads),
+            '--continuous-saving',
+            '--message-verbosity', 'fatal',
+            '--resolution', str(width), str(height),
+            '--window', str(x), str(y), str(endX), str(endY))
+
+    # Launch appleseed.cli.
+    process = subprocess.Popen( cmd, cwd=as_bin_path, env = os.environ.copy())
         
-        # Wait for the rendered image file to be created
-        while not os.path.exists( img_file):
+    # Wait for the rendered image file to be created
+    while not os.path.exists( img_file):
+        if engine.test_break():
+            try:
+                process.kill()
+            except:
+                pass
+            break
+
+        if process.poll() != None:
+            engine.update_stats( "", "Appleseed: Error")
+            break
+
+        time.sleep( DELAY)
+
+    if os.path.exists( img_file):
+        engine.update_stats( "", "Appleseed: Rendering")
+
+        prev_size = -1
+
+        def update_image():
+            result = engine.begin_result( 0, 0, width, height)
+            lay = result.layers[0]
+            # it's possible the image wont load early on.
+            try:
+                lay.load_from_file( img_file)
+            except:
+                pass
+
+            engine.end_result( result)
+
+        # Update while rendering
+        while True:
+            if process.poll() != None:
+                update_image()
+                break
+
+            # user exit
             if engine.test_break():
                 try:
                     process.kill()
@@ -242,60 +277,14 @@ def render_scene( engine, scene):
                     pass
                 break
 
-            if process.poll() != None:
-                engine.update_stats( "", "Appleseed: Error")
-                break
+            # check if the file updated
+            new_size = os.path.getsize( img_file)
+
+            #if new_size != prev_size:
+            update_image()
+            #    prev_size = new_size
 
             time.sleep( DELAY)
-
-        if os.path.exists( img_file):
-            engine.update_stats( "", "Appleseed: Rendering")
-
-            prev_size = -1
-
-            def update_image():
-                result = engine.begin_result( 0, 0, width, height)
-                lay = result.layers[0]
-                # it's possible the image wont load early on.
-                try:
-                    lay.load_from_file( img_file)
-                except:
-                    pass
-
-                engine.end_result( result)
-
-            # Update while rendering
-            while True:
-                if process.poll() != None:
-                    update_image()
-                    break
-
-                # user exit
-                if engine.test_break():
-                    try:
-                        process.kill()
-                    except:
-                        pass
-                    break
-
-                # check if the file updated
-                new_size = os.path.getsize( img_file)
-
-                #if new_size != prev_size:
-                update_image()
-                #    prev_size = new_size
-
-                time.sleep( DELAY)
-
-    else:
-        # If rendering with GUI, we have two options
-        if scene.appleseed.studio_rendering_mode == "PROGRESSIVE":
-            cmd = (appleseed_exe, filename, "--render", "interactive")
-        else:
-            cmd = (appleseed_exe, filename, "--render", "final")
-
-        # Launch appleseed.studio.
-        process = subprocess.Popen( cmd, cwd=as_bin_path, env = os.environ.copy())
     
 
 class RenderAppleseed( bpy.types.RenderEngine):

--- a/ui/render.py
+++ b/ui/render.py
@@ -38,28 +38,6 @@ class AppleseedRenderPanelBase( object):
         renderer = context.scene.render
         return renderer.engine == 'APPLESEED_RENDER'
 
-class AppleseedRenderButtons( bpy.types.Panel, AppleseedRenderPanelBase):
-    bl_label = "Render"
-    
-    def draw( self, context):
-        scene = context.scene
-        layout = self.layout
-
-        if scene.appleseed.display_mode != 'STUDIO':
-            row = layout.row( align=True)
-            row.operator( "render.render", text="Render", icon = 'RENDER_STILL')
-            row.operator( "render.render", text = "Animation", icon = 'RENDER_ANIMATION').animation = True
-            
-        else:
-            layout.operator( "render.render", text="Render", icon='RENDER_STILL')
-
-        layout.prop( scene.appleseed, "display_mode")
-        if not scene.appleseed.display_mode == 'STUDIO':
-            layout.prop(scene.appleseed, "refresh_time")
-
-        if scene.appleseed.display_mode == 'STUDIO':
-            layout.prop( scene.appleseed, "studio_rendering_mode")
-
 class AppleseedRenderSettingsPanel( bpy.types.Panel, AppleseedRenderPanelBase):
     COMPAT_ENGINES = {'APPLESEED_RENDER'}
     bl_label = "Settings"
@@ -69,7 +47,6 @@ class AppleseedRenderSettingsPanel( bpy.types.Panel, AppleseedRenderPanelBase):
         scene = context.scene
         asr_scene_props = scene.appleseed
         layout.prop( asr_scene_props, "project_path", text = "Project Path")
-        layout.prop( asr_scene_props, "img_extension")
         split = layout.split()
         col = split.column()
         col.label( "Render Threads:")
@@ -216,15 +193,15 @@ class AppleseedMotionBlurPanel( bpy.types.Panel, AppleseedRenderPanelBase):
         row.prop( asr_scene_props, "shutter_close")
 
 def register():
-    bpy.utils.register_class( AppleseedRenderButtons)
+    bpy.types.RENDER_PT_render.COMPAT_ENGINES.add( 'APPLESEED_RENDER')
     bpy.types.RENDER_PT_dimensions.COMPAT_ENGINES.add( 'APPLESEED_RENDER')
+    bpy.types.RENDER_PT_output.COMPAT_ENGINES.add( 'APPLESEED_RENDER')
     bpy.utils.register_class( AppleseedRenderSettingsPanel)
     bpy.utils.register_class( AppleseedSamplingPanel)
     bpy.utils.register_class( AppleseedLightingPanel)
     bpy.utils.register_class( AppleseedMotionBlurPanel)
 
 def unregister():
-    bpy.utils.unregister_class( AppleseedRenderButtons)
     bpy.utils.unregister_class( AppleseedRenderSettingsPanel)
     bpy.utils.unregister_class( AppleseedSamplingPanel)
     bpy.utils.unregister_class( AppleseedLightingPanel)


### PR DESCRIPTION
- Always render linear rgb exr files internally (fixes wrong colorspace for exr files).
- Use the filename extension of textures to set the colorspace.
- Let Blender handle image output, use standard render output panel.
- Removed the refresh delay parameter. appleseed now has a workaround for Blender crashing when 
reading incomplete images on unix.
- Remove the option to render to appleseed studio. This can be done easily by exporting and watching the project file in studio. instead, use the standard render panel.
