### PR TITLE
Fix rendering on linux with custom appleseed builds.

### DIFF
--- a/render.py
+++ b/render.py
@@ -168,10 +168,6 @@ class RenderAppleseed(bpy.types.RenderEngine):
             return
         appleseed_exe = os.path.join(as_bin_path, "appleseed.cli")
 
-        # If running Linux/macOS, add the binary path to environment.
-        if sys.platform != "win32":
-            os.environ['LD_LIBRARY_PATH'] = as_bin_path
-
         # Compute render resolution.
         (width, height) = util.get_render_resolution(scene)
 


### PR DESCRIPTION
For linux users using released binaries, this is not needed. Runtime paths take care of this automatically.
On OSX the correct env var is DYLD_LIBRARY_PATH and shouldn't be needed either.

For users using their own appleseed build, this is wrong. We cannot really know where libs are and how they are located. It's better to rely on the existing environment variables in the system.

Also $APPLESEED/bin does not contain any shared libs on linux.